### PR TITLE
Add missing OBO namespaces with underscores

### DIFF
--- a/phipo.obo
+++ b/phipo.obo
@@ -21,6 +21,7 @@ creation_date: 2018-05-02T11:20:59Z
 [Term]
 id: PHIPO:0000003
 name: host phenotype
+namespace: host phenotype
 def: "testing" []
 created_by: alaynecuzick
 creation_date: 2018-05-02T11:21:13Z
@@ -28,6 +29,7 @@ creation_date: 2018-05-02T11:21:13Z
 [Term]
 id: PHIPO:0000004
 name: normal pathogenicity
+namespace: disease formation phenotype
 synonym: "unaffected pathogenicity" EXACT []
 is_a: PHIPO:0000006 ! pathogenicity phenotype
 created_by: alaynecuzick
@@ -36,6 +38,7 @@ creation_date: 2018-05-04T12:38:43Z
 [Term]
 id: PHIPO:0000005
 name: abnormal pathogenicity
+namespace: disease formation phenotype
 is_a: PHIPO:0000006 ! pathogenicity phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T12:39:00Z
@@ -43,6 +46,7 @@ creation_date: 2018-05-04T12:39:00Z
 [Term]
 id: PHIPO:0000006
 name: pathogenicity phenotype
+namespace: disease formation phenotype
 is_a: PHIPO:0000001 ! disease formation phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T12:39:55Z
@@ -50,6 +54,7 @@ creation_date: 2018-05-04T12:39:55Z
 [Term]
 id: PHIPO:0000007
 name: normal pathogenic phenotype
+namespace: disease formation phenotype
 is_a: PHIPO:0000004 ! normal pathogenicity
 created_by: alaynecuzick
 creation_date: 2018-05-04T12:42:00Z
@@ -57,6 +62,7 @@ creation_date: 2018-05-04T12:42:00Z
 [Term]
 id: PHIPO:0000008
 name: normal non pathogenic phenotype
+namespace: disease formation phenotype
 is_a: PHIPO:0000004 ! normal pathogenicity
 created_by: alaynecuzick
 creation_date: 2018-05-04T12:42:16Z
@@ -64,6 +70,7 @@ creation_date: 2018-05-04T12:42:16Z
 [Term]
 id: PHIPO:0000009
 name: gain of pathogenicity
+namespace: disease formation phenotype
 synonym: "abnormal pathogenic phenotype" EXACT []
 is_a: PHIPO:0000005 ! abnormal pathogenicity
 created_by: alaynecuzick
@@ -72,6 +79,7 @@ creation_date: 2018-05-04T12:45:12Z
 [Term]
 id: PHIPO:0000010
 name: loss of pathogenicity
+namespace: disease formation phenotype
 synonym: "abnormal non pathogenic phenotype" EXACT []
 is_a: PHIPO:0000005 ! abnormal pathogenicity
 created_by: alaynecuzick
@@ -80,6 +88,7 @@ creation_date: 2018-05-04T12:45:31Z
 [Term]
 id: PHIPO:0000011
 name: virulence phenotype
+namespace: disease formation phenotype
 is_a: PHIPO:0000001 ! disease formation phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:02:03Z
@@ -87,6 +96,7 @@ creation_date: 2018-05-04T13:02:03Z
 [Term]
 id: PHIPO:0000012
 name: normal virulence
+namespace: disease formation phenotype
 synonym: "unaffected virulence" EXACT []
 is_a: PHIPO:0000011 ! virulence phenotype
 created_by: alaynecuzick
@@ -95,6 +105,7 @@ creation_date: 2018-05-04T13:02:23Z
 [Term]
 id: PHIPO:0000013
 name: abnormal virulence
+namespace: disease formation phenotype
 is_a: PHIPO:0000011 ! virulence phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:02:39Z
@@ -102,6 +113,7 @@ creation_date: 2018-05-04T13:02:39Z
 [Term]
 id: PHIPO:0000014
 name: increased virulence
+namespace: disease formation phenotype
 is_a: PHIPO:0000013 ! abnormal virulence
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:07:31Z
@@ -109,6 +121,7 @@ creation_date: 2018-05-04T13:07:31Z
 [Term]
 id: PHIPO:0000015
 name: reduced virulence
+namespace: disease formation phenotype
 synonym: "decreased virulence" EXACT []
 is_a: PHIPO:0000013 ! abnormal virulence
 created_by: alaynecuzick
@@ -117,6 +130,7 @@ creation_date: 2018-05-04T13:08:10Z
 [Term]
 id: PHIPO:0000016
 name: normal pathogen phenotype
+namespace: pathogen phenotype
 is_a: PHIPO:0000002 ! pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:10:48Z
@@ -124,6 +138,7 @@ creation_date: 2018-05-04T13:10:48Z
 [Term]
 id: PHIPO:0000017
 name: abnormal pathogen phenotype
+namespace: pathogen phenotype
 is_a: PHIPO:0000002 ! pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:11:04Z
@@ -131,6 +146,7 @@ creation_date: 2018-05-04T13:11:04Z
 [Term]
 id: PHIPO:0000018
 name: sensitive to chemical
+namespace: pathogen phenotype
 is_a: PHIPO:0000016 ! normal pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:12:20Z
@@ -138,6 +154,7 @@ creation_date: 2018-05-04T13:12:20Z
 [Term]
 id: PHIPO:0000019
 name: lethal
+namespace: pathogen phenotype
 is_a: PHIPO:0000017 ! abnormal pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:12:47Z
@@ -145,6 +162,7 @@ creation_date: 2018-05-04T13:12:47Z
 [Term]
 id: PHIPO:0000020
 name: abnormal chemical target phenotype
+namespace: pathogen phenotype
 is_a: PHIPO:0000017 ! abnormal pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:13:42Z
@@ -152,6 +170,7 @@ creation_date: 2018-05-04T13:13:42Z
 [Term]
 id: PHIPO:0000021
 name: increased sensitivity to chemical
+namespace: pathogen phenotype
 is_a: PHIPO:0000020 ! abnormal chemical target phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:15:05Z
@@ -159,6 +178,7 @@ creation_date: 2018-05-04T13:15:05Z
 [Term]
 id: PHIPO:0000022
 name: resistance to chemical
+namespace: pathogen phenotype
 is_a: PHIPO:0000020 ! abnormal chemical target phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:16:06Z
@@ -166,6 +186,7 @@ creation_date: 2018-05-04T13:16:06Z
 [Term]
 id: PHIPO:0000023
 name: abnormal penetration assay phenotype
+namespace: pathogen phenotype
 is_a: PHIPO:0000002 ! pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:16:54Z
@@ -173,6 +194,7 @@ creation_date: 2018-05-04T13:16:54Z
 [Term]
 id: PHIPO:0000024
 name: normal penetration assay phenotype
+namespace: pathogen phenotype
 is_a: PHIPO:0000016 ! normal pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:17:08Z
@@ -180,6 +202,7 @@ creation_date: 2018-05-04T13:17:08Z
 [Term]
 id: PHIPO:0000025
 name: normal mating phenotype prior to penetration
+namespace: pathogen phenotype
 is_a: PHIPO:0000024 ! normal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:17:46Z
@@ -187,6 +210,7 @@ creation_date: 2018-05-04T13:17:46Z
 [Term]
 id: PHIPO:0000026
 name: normal penetration
+namespace: pathogen phenotype
 is_a: PHIPO:0000024 ! normal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:18:03Z
@@ -194,6 +218,7 @@ creation_date: 2018-05-04T13:18:03Z
 [Term]
 id: PHIPO:0000027
 name: normal post penetration
+namespace: pathogen phenotype
 is_a: PHIPO:0000024 ! normal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:19:13Z
@@ -201,6 +226,7 @@ creation_date: 2018-05-04T13:19:13Z
 [Term]
 id: PHIPO:0000028
 name: normal pre penetration
+namespace: pathogen phenotype
 is_a: PHIPO:0000024 ! normal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:19:44Z
@@ -208,6 +234,7 @@ creation_date: 2018-05-04T13:19:44Z
 [Term]
 id: PHIPO:0000029
 name: abnormal mating phenotype prior to penetration
+namespace: pathogen phenotype
 is_a: PHIPO:0000023 ! abnormal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:22:14Z
@@ -215,6 +242,7 @@ creation_date: 2018-05-04T13:22:14Z
 [Term]
 id: PHIPO:0000030
 name: abnormal penetration
+namespace: pathogen phenotype
 is_a: PHIPO:0000023 ! abnormal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:22:31Z
@@ -222,6 +250,7 @@ creation_date: 2018-05-04T13:22:31Z
 [Term]
 id: PHIPO:0000031
 name: abnormal post penetration
+namespace: pathogen phenotype
 is_a: PHIPO:0000023 ! abnormal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:22:52Z
@@ -229,6 +258,7 @@ creation_date: 2018-05-04T13:22:52Z
 [Term]
 id: PHIPO:0000032
 name: abnormal pre penetration
+namespace: pathogen phenotype
 is_a: PHIPO:0000023 ! abnormal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:23:06Z

--- a/phipo.obo
+++ b/phipo.obo
@@ -4,7 +4,7 @@ ontology: http://www.purl.obolibrary.org/obo/phipo.owl
 [Term]
 id: PHIPO:0000001
 name: disease formation phenotype
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 def: "TO UPDATE_Any of the set of observable characteristics of an organism resulting from the interaction of its genotype with the environment including any other organisms" []
 comment: This is a high-level term whose primary purpose is to organize terms beneath it in the ontology, and we expect that it will not be used for direct annotations. Please consider using a more specific term to annotate each phenotype.
 subset: qc_do_not_annotate
@@ -21,7 +21,7 @@ creation_date: 2018-05-02T11:20:59Z
 [Term]
 id: PHIPO:0000003
 name: host phenotype
-namespace: host phenotype
+namespace: host_phenotype
 def: "testing" []
 created_by: alaynecuzick
 creation_date: 2018-05-02T11:21:13Z
@@ -29,7 +29,7 @@ creation_date: 2018-05-02T11:21:13Z
 [Term]
 id: PHIPO:0000004
 name: normal pathogenicity
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 synonym: "unaffected pathogenicity" EXACT []
 is_a: PHIPO:0000006 ! pathogenicity phenotype
 created_by: alaynecuzick
@@ -38,7 +38,7 @@ creation_date: 2018-05-04T12:38:43Z
 [Term]
 id: PHIPO:0000005
 name: abnormal pathogenicity
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 is_a: PHIPO:0000006 ! pathogenicity phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T12:39:00Z
@@ -46,7 +46,7 @@ creation_date: 2018-05-04T12:39:00Z
 [Term]
 id: PHIPO:0000006
 name: pathogenicity phenotype
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 is_a: PHIPO:0000001 ! disease formation phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T12:39:55Z
@@ -54,7 +54,7 @@ creation_date: 2018-05-04T12:39:55Z
 [Term]
 id: PHIPO:0000007
 name: normal pathogenic phenotype
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 is_a: PHIPO:0000004 ! normal pathogenicity
 created_by: alaynecuzick
 creation_date: 2018-05-04T12:42:00Z
@@ -62,7 +62,7 @@ creation_date: 2018-05-04T12:42:00Z
 [Term]
 id: PHIPO:0000008
 name: normal non pathogenic phenotype
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 is_a: PHIPO:0000004 ! normal pathogenicity
 created_by: alaynecuzick
 creation_date: 2018-05-04T12:42:16Z
@@ -70,7 +70,7 @@ creation_date: 2018-05-04T12:42:16Z
 [Term]
 id: PHIPO:0000009
 name: gain of pathogenicity
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 synonym: "abnormal pathogenic phenotype" EXACT []
 is_a: PHIPO:0000005 ! abnormal pathogenicity
 created_by: alaynecuzick
@@ -79,7 +79,7 @@ creation_date: 2018-05-04T12:45:12Z
 [Term]
 id: PHIPO:0000010
 name: loss of pathogenicity
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 synonym: "abnormal non pathogenic phenotype" EXACT []
 is_a: PHIPO:0000005 ! abnormal pathogenicity
 created_by: alaynecuzick
@@ -88,7 +88,7 @@ creation_date: 2018-05-04T12:45:31Z
 [Term]
 id: PHIPO:0000011
 name: virulence phenotype
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 is_a: PHIPO:0000001 ! disease formation phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:02:03Z
@@ -96,7 +96,7 @@ creation_date: 2018-05-04T13:02:03Z
 [Term]
 id: PHIPO:0000012
 name: normal virulence
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 synonym: "unaffected virulence" EXACT []
 is_a: PHIPO:0000011 ! virulence phenotype
 created_by: alaynecuzick
@@ -105,7 +105,7 @@ creation_date: 2018-05-04T13:02:23Z
 [Term]
 id: PHIPO:0000013
 name: abnormal virulence
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 is_a: PHIPO:0000011 ! virulence phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:02:39Z
@@ -113,7 +113,7 @@ creation_date: 2018-05-04T13:02:39Z
 [Term]
 id: PHIPO:0000014
 name: increased virulence
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 is_a: PHIPO:0000013 ! abnormal virulence
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:07:31Z
@@ -121,7 +121,7 @@ creation_date: 2018-05-04T13:07:31Z
 [Term]
 id: PHIPO:0000015
 name: reduced virulence
-namespace: disease formation phenotype
+namespace: disease_formation_phenotype
 synonym: "decreased virulence" EXACT []
 is_a: PHIPO:0000013 ! abnormal virulence
 created_by: alaynecuzick
@@ -130,7 +130,7 @@ creation_date: 2018-05-04T13:08:10Z
 [Term]
 id: PHIPO:0000016
 name: normal pathogen phenotype
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000002 ! pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:10:48Z
@@ -138,7 +138,7 @@ creation_date: 2018-05-04T13:10:48Z
 [Term]
 id: PHIPO:0000017
 name: abnormal pathogen phenotype
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000002 ! pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:11:04Z
@@ -146,7 +146,7 @@ creation_date: 2018-05-04T13:11:04Z
 [Term]
 id: PHIPO:0000018
 name: sensitive to chemical
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000016 ! normal pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:12:20Z
@@ -154,7 +154,7 @@ creation_date: 2018-05-04T13:12:20Z
 [Term]
 id: PHIPO:0000019
 name: lethal
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000017 ! abnormal pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:12:47Z
@@ -162,7 +162,7 @@ creation_date: 2018-05-04T13:12:47Z
 [Term]
 id: PHIPO:0000020
 name: abnormal chemical target phenotype
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000017 ! abnormal pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:13:42Z
@@ -170,7 +170,7 @@ creation_date: 2018-05-04T13:13:42Z
 [Term]
 id: PHIPO:0000021
 name: increased sensitivity to chemical
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000020 ! abnormal chemical target phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:15:05Z
@@ -178,7 +178,7 @@ creation_date: 2018-05-04T13:15:05Z
 [Term]
 id: PHIPO:0000022
 name: resistance to chemical
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000020 ! abnormal chemical target phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:16:06Z
@@ -186,7 +186,7 @@ creation_date: 2018-05-04T13:16:06Z
 [Term]
 id: PHIPO:0000023
 name: abnormal penetration assay phenotype
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000002 ! pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:16:54Z
@@ -194,7 +194,7 @@ creation_date: 2018-05-04T13:16:54Z
 [Term]
 id: PHIPO:0000024
 name: normal penetration assay phenotype
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000016 ! normal pathogen phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:17:08Z
@@ -202,7 +202,7 @@ creation_date: 2018-05-04T13:17:08Z
 [Term]
 id: PHIPO:0000025
 name: normal mating phenotype prior to penetration
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000024 ! normal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:17:46Z
@@ -210,7 +210,7 @@ creation_date: 2018-05-04T13:17:46Z
 [Term]
 id: PHIPO:0000026
 name: normal penetration
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000024 ! normal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:18:03Z
@@ -218,7 +218,7 @@ creation_date: 2018-05-04T13:18:03Z
 [Term]
 id: PHIPO:0000027
 name: normal post penetration
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000024 ! normal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:19:13Z
@@ -226,7 +226,7 @@ creation_date: 2018-05-04T13:19:13Z
 [Term]
 id: PHIPO:0000028
 name: normal pre penetration
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000024 ! normal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:19:44Z
@@ -234,7 +234,7 @@ creation_date: 2018-05-04T13:19:44Z
 [Term]
 id: PHIPO:0000029
 name: abnormal mating phenotype prior to penetration
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000023 ! abnormal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:22:14Z
@@ -242,7 +242,7 @@ creation_date: 2018-05-04T13:22:14Z
 [Term]
 id: PHIPO:0000030
 name: abnormal penetration
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000023 ! abnormal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:22:31Z
@@ -250,7 +250,7 @@ creation_date: 2018-05-04T13:22:31Z
 [Term]
 id: PHIPO:0000031
 name: abnormal post penetration
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000023 ! abnormal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:22:52Z
@@ -258,7 +258,7 @@ creation_date: 2018-05-04T13:22:52Z
 [Term]
 id: PHIPO:0000032
 name: abnormal pre penetration
-namespace: pathogen phenotype
+namespace: pathogen_phenotype
 is_a: PHIPO:0000023 ! abnormal penetration assay phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-04T13:23:06Z

--- a/phipo.obo
+++ b/phipo.obo
@@ -15,6 +15,7 @@ creation_date: 2018-05-02T11:20:17Z
 [Term]
 id: PHIPO:0000002
 name: pathogen phenotype
+namespace: pathogen_phenotype
 created_by: alaynecuzick
 creation_date: 2018-05-02T11:20:59Z
 

--- a/phipo.owl
+++ b/phipo.owl
@@ -104,6 +104,7 @@
     <owl:Class rdf:about="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000002">
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-02T11:20:59Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">pathogen phenotype</rdfs:label>
     </owl:Class>
     

--- a/phipo.owl
+++ b/phipo.owl
@@ -90,7 +90,7 @@
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TO UPDATE_Any of the set of observable characteristics of an organism resulting from the interaction of its genotype with the environment including any other organisms</obo:IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-02T11:20:17Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <oboInOwl:inSubset rdf:datatype="http://www.w3.org/2001/XMLSchema#string">qc_do_not_annotate</oboInOwl:inSubset>
         <oboInOwl:inSubset rdf:datatype="http://www.w3.org/2001/XMLSchema#string">qc_do_not_manually_annotate</oboInOwl:inSubset>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is a high-level term whose primary purpose is to organize terms beneath it in the ontology, and we expect that it will not be used for direct annotations. Please consider using a more specific term to annotate each phenotype.</rdfs:comment>
@@ -115,7 +115,7 @@
         <obo:IAO_0000115>testing</obo:IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-02T11:21:13Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">host phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">host_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">host phenotype</rdfs:label>
     </owl:Class>
     
@@ -128,7 +128,7 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:38:43Z</oboInOwl:creation_date>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unaffected pathogenicity</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal pathogenicity</rdfs:label>
     </owl:Class>
     
@@ -140,7 +140,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000006"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:39:00Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal pathogenicity</rdfs:label>
     </owl:Class>
     
@@ -152,7 +152,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000001"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:39:55Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">pathogenicity phenotype</rdfs:label>
     </owl:Class>
     
@@ -164,7 +164,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000004"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:42:00Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal pathogenic phenotype</rdfs:label>
     </owl:Class>
     
@@ -176,7 +176,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000004"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:42:16Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal non pathogenic phenotype</rdfs:label>
     </owl:Class>
     
@@ -189,7 +189,7 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:45:12Z</oboInOwl:creation_date>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abnormal pathogenic phenotype</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">gain of pathogenicity</rdfs:label>
     </owl:Class>
     
@@ -202,7 +202,7 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:45:31Z</oboInOwl:creation_date>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abnormal non pathogenic phenotype</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">loss of pathogenicity</rdfs:label>
     </owl:Class>
     
@@ -214,7 +214,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000001"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:02:03Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">virulence phenotype</rdfs:label>
     </owl:Class>
     
@@ -227,7 +227,7 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:02:23Z</oboInOwl:creation_date>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unaffected virulence</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal virulence</rdfs:label>
     </owl:Class>
     
@@ -239,7 +239,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000011"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:02:39Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal virulence</rdfs:label>
     </owl:Class>
     
@@ -251,7 +251,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000013"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:07:31Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">increased virulence</rdfs:label>
     </owl:Class>
     
@@ -264,7 +264,7 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:08:10Z</oboInOwl:creation_date>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">decreased virulence</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease_formation_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">reduced virulence</rdfs:label>
     </owl:Class>
     
@@ -276,7 +276,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000002"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:10:48Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal pathogen phenotype</rdfs:label>
     </owl:Class>
     
@@ -288,7 +288,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000002"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:11:04Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal pathogen phenotype</rdfs:label>
     </owl:Class>
     
@@ -300,7 +300,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000016"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:12:20Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">sensitive to chemical</rdfs:label>
     </owl:Class>
     
@@ -312,7 +312,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000017"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:12:47Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">lethal</rdfs:label>
     </owl:Class>
     
@@ -324,7 +324,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000017"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:13:42Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal chemical target phenotype</rdfs:label>
     </owl:Class>
     
@@ -336,7 +336,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000020"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:15:05Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">increased sensitivity to chemical</rdfs:label>
     </owl:Class>
     
@@ -348,7 +348,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000020"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:16:06Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">resistance to chemical</rdfs:label>
     </owl:Class>
     
@@ -360,7 +360,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000002"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:16:54Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal penetration assay phenotype</rdfs:label>
     </owl:Class>
     
@@ -372,7 +372,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000016"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:17:08Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal penetration assay phenotype</rdfs:label>
     </owl:Class>
     
@@ -384,7 +384,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000024"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:17:46Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal mating phenotype prior to penetration</rdfs:label>
     </owl:Class>
     
@@ -396,7 +396,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000024"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:18:03Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal penetration</rdfs:label>
     </owl:Class>
     
@@ -408,7 +408,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000024"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:19:13Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal post penetration</rdfs:label>
     </owl:Class>
     
@@ -420,7 +420,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000024"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:19:44Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal pre penetration</rdfs:label>
     </owl:Class>
     
@@ -432,7 +432,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000023"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:22:14Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal mating phenotype prior to penetration</rdfs:label>
     </owl:Class>
     
@@ -444,7 +444,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000023"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:22:31Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal penetration</rdfs:label>
     </owl:Class>
     
@@ -456,7 +456,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000023"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:22:52Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal post penetration</rdfs:label>
     </owl:Class>
     
@@ -468,7 +468,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000023"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:23:06Z</oboInOwl:creation_date>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen_phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal pre penetration</rdfs:label>
     </owl:Class>
 </rdf:RDF>

--- a/phipo.owl
+++ b/phipo.owl
@@ -115,6 +115,7 @@
         <obo:IAO_0000115>testing</obo:IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-02T11:21:13Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">host phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">host phenotype</rdfs:label>
     </owl:Class>
     
@@ -127,6 +128,7 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:38:43Z</oboInOwl:creation_date>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unaffected pathogenicity</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal pathogenicity</rdfs:label>
     </owl:Class>
     
@@ -138,6 +140,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000006"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:39:00Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal pathogenicity</rdfs:label>
     </owl:Class>
     
@@ -149,6 +152,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000001"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:39:55Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">pathogenicity phenotype</rdfs:label>
     </owl:Class>
     
@@ -160,6 +164,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000004"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:42:00Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal pathogenic phenotype</rdfs:label>
     </owl:Class>
     
@@ -171,6 +176,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000004"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:42:16Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal non pathogenic phenotype</rdfs:label>
     </owl:Class>
     
@@ -183,6 +189,7 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:45:12Z</oboInOwl:creation_date>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abnormal pathogenic phenotype</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">gain of pathogenicity</rdfs:label>
     </owl:Class>
     
@@ -195,6 +202,7 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T12:45:31Z</oboInOwl:creation_date>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abnormal non pathogenic phenotype</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">loss of pathogenicity</rdfs:label>
     </owl:Class>
     
@@ -206,6 +214,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000001"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:02:03Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">virulence phenotype</rdfs:label>
     </owl:Class>
     
@@ -218,6 +227,7 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:02:23Z</oboInOwl:creation_date>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unaffected virulence</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal virulence</rdfs:label>
     </owl:Class>
     
@@ -229,6 +239,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000011"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:02:39Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal virulence</rdfs:label>
     </owl:Class>
     
@@ -240,6 +251,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000013"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:07:31Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">increased virulence</rdfs:label>
     </owl:Class>
     
@@ -252,6 +264,7 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:08:10Z</oboInOwl:creation_date>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">decreased virulence</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disease formation phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">reduced virulence</rdfs:label>
     </owl:Class>
     
@@ -263,6 +276,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000002"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:10:48Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal pathogen phenotype</rdfs:label>
     </owl:Class>
     
@@ -274,6 +288,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000002"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:11:04Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal pathogen phenotype</rdfs:label>
     </owl:Class>
     
@@ -285,6 +300,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000016"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:12:20Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">sensitive to chemical</rdfs:label>
     </owl:Class>
     
@@ -296,6 +312,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000017"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:12:47Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">lethal</rdfs:label>
     </owl:Class>
     
@@ -307,6 +324,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000017"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:13:42Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal chemical target phenotype</rdfs:label>
     </owl:Class>
     
@@ -318,6 +336,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000020"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:15:05Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">increased sensitivity to chemical</rdfs:label>
     </owl:Class>
     
@@ -329,6 +348,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000020"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:16:06Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">resistance to chemical</rdfs:label>
     </owl:Class>
     
@@ -340,6 +360,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000002"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:16:54Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal penetration assay phenotype</rdfs:label>
     </owl:Class>
     
@@ -351,6 +372,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000016"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:17:08Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal penetration assay phenotype</rdfs:label>
     </owl:Class>
     
@@ -362,6 +384,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000024"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:17:46Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal mating phenotype prior to penetration</rdfs:label>
     </owl:Class>
     
@@ -373,6 +396,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000024"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:18:03Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal penetration</rdfs:label>
     </owl:Class>
     
@@ -384,6 +408,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000024"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:19:13Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal post penetration</rdfs:label>
     </owl:Class>
     
@@ -395,6 +420,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000024"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:19:44Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">normal pre penetration</rdfs:label>
     </owl:Class>
     
@@ -406,6 +432,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000023"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:22:14Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal mating phenotype prior to penetration</rdfs:label>
     </owl:Class>
     
@@ -417,6 +444,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000023"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:22:31Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal penetration</rdfs:label>
     </owl:Class>
     
@@ -428,6 +456,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000023"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:22:52Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal post penetration</rdfs:label>
     </owl:Class>
     
@@ -439,6 +468,7 @@
         <rdfs:subClassOf rdf:resource="http://www.purl.obolibrary.org/obo/phipo.owl/PHIPO_0000023"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alaynecuzick</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-04T13:23:06Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogen phenotype</oboInOwl:hasOBONamespace>
         <rdfs:label xml:lang="en">abnormal pre penetration</rdfs:label>
     </owl:Class>
 </rdf:RDF>


### PR DESCRIPTION
(Fixes issue #15 and issue #16.)

The current OBO and OWL files were missing the `namespace` and `hasOBONamespace` properties, respectively. The namespace properties were also using spaces instead of underscores, which was causing problems when loading the ontology into Canto.