### PR TITLE
Disable strict mode when converting to OBO

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -46,8 +46,10 @@ prepare_release: all
 # after that we annotate the ontology with the release versionInfo
 $(ONT).owl: $(SRC)
 	$(ROBOT)  reason -i $< -r ELK relax reduce -r ELK annotate -V $(BASE)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
-$(ONT).obo: $(ONT).owl
-	$(ROBOT) convert -i $< -f obo -o $(ONT).obo.tmp && mv $(ONT).obo.tmp $@
+# we have to set strict mode (--check) to false to generate the OBO file
+# see https://github.com/PHI-base/phipo/issues/30
+  $(ONT).obo: $(ONT).owl
+	$(ROBOT) convert --check false -i $< -f obo -o $(ONT).obo.tmp && mv $(ONT).obo.tmp $@
 
 # ----------------------------------------
 # Import modules


### PR DESCRIPTION
Fixes #30.

At some point since commit b00c3cbd463c956b159ce8967cc23b8cdf873dd3, converting PHIPO to OBO file format has failed with an error, as documented in the issue above. Disabling strict checking of the OBO file prevents the error, and should still allow the OBO file to be loaded into Canto. This fix isn't ideal, but it's recommended by the ODK developers since the OBO file can sometimes fail on things that don't necessitate this sort of failure.