### PR TITLE
Fix ChEBI download error by using wget

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -89,9 +89,10 @@ imports/%_import.owl: mirror/%.owl imports/%_terms_combined.txt
 imports/%_import.obo: imports/%_import.owl
 	$(ROBOT) convert --check false -i $< -f obo -o $@.tmp && mv $@.tmp $@
 
-# clone remote ontology locally, perfoming some excision of relations and annotations
+# clone remote ontology locally; wget is used instead of ROBOT to
+# prevent Travis-CI failing on large ontologies.
 mirror/%.owl: $(SRC)
-	$(ROBOT) convert -I $(OBO)/$*.owl -o $@
+	mkdir -p mirror && wget -O $@ $(OBO)/$*.owl
 .PRECIOUS: mirror/%.owl
 
 # ----------------------------------------


### PR DESCRIPTION
(Fixes #29)

This is a quick workaround to stop Travis-CI failing when loading larger ontologies like ChEBI. Long-term, OBOFoundry or some other organisation might be able to provide PURLs for the compressed copies of the OBOLibrary ontologies, so the ODK will attempt to download the compressed version first, before falling back to the uncompressed version if that fails.