### PR TITLE
Fix wrong property being used for the definition of `PHIPO:0001225`

### DIFF
--- a/src/ontology/phipo-edit.owl
+++ b/src/ontology/phipo-edit.owl
@@ -12022,9 +12022,9 @@ SubClassOf(obo:PHIPO_0001224 obo:PHIPO_0000413)
 
 # Class: obo:PHIPO_0001225 (abolished PAMP receptor decoy activity)
 
+AnnotationAssertion(obo:IAO_0000115 obo:PHIPO_0001225 "A single species molecular function phenotype in which the occurrence of recognition, binding and sequestering of PAMP ligands in order to prevent them from binding and activating the host PAMP receptor is abolished (was present and is now absent).")
 AnnotationAssertion(oboInOwl:created_by obo:PHIPO_0001225 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PHIPO_0001225 "2021-01-26T14:26:23Z"^^xsd:dateTime)
-AnnotationAssertion(oboInOwl:hasOBONamespace obo:PHIPO_0001225 "A single species molecular function phenotype in which the occurrence of recognition, binding and sequestering of PAMP ligands in order to prevent them from binding and activating the host PAMP receptor is abolished (was present and is now absent).")
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:PHIPO_0001225 "single_species_phenotype")
 AnnotationAssertion(rdfs:label obo:PHIPO_0001225 "abolished PAMP receptor decoy activity"@en)
 SubClassOf(obo:PHIPO_0001225 obo:PHIPO_0000413)


### PR DESCRIPTION
Hi !

The definition of `PHIPO:0001225` was being added with the wrong property, which was incorrect semantically, and incidentally induced syntax errors in the final OBO product, causing the definition to be written using a `namespace` clause instead.